### PR TITLE
Update path with anaconda in dockerfile - can't build w/o it

### DIFF
--- a/docker/2_7/Dockerfile
+++ b/docker/2_7/Dockerfile
@@ -21,6 +21,8 @@ FROM continuumio/anaconda:latest as python_build
 
 COPY --from=node_build /workspace /workspace
 
+ENV PATH="/opt/conda/bin/:${PATH}"
+
 WORKDIR /workspace
 RUN set -eux \
   ; pip install six \

--- a/docker/3_6/Dockerfile
+++ b/docker/3_6/Dockerfile
@@ -21,6 +21,8 @@ FROM continuumio/anaconda3:latest as python_build
 
 COPY --from=node_build /workspace /workspace
 
+ENV PATH="/opt/conda/bin/:${PATH}"
+
 WORKDIR /workspace
 RUN set -eux \
   ; pip install six \


### PR DESCRIPTION
The anaconda path needs to be explicitely added to the path when
building in docker:

 ---> Running in 4dd60948ffa2
+ pip install six
/bin/sh: 1: pip: not found
ERROR: Service 'dtale_2_7' failed to build: The command '/bin/sh -c set -eux   ; pip install six   ; pip install lxml   ; pip install isort   ; pip install -r docs/source/requirements.txt   ; python setup.py develop   ; python setup.py build_sphinx   ; isort --recursive -c -vb setup.py dtale tests   ; export TZ=America/New_York   ; python setup.py test   ; python setup.py bdist_egg' returned a non-zero code: 127